### PR TITLE
feat(round): Add timestamp to round model

### DIFF
--- a/round/models.py
+++ b/round/models.py
@@ -1,16 +1,29 @@
 from django.db import models
+from django.db.models import Q
 from random import randint
 
+from round.utils import TimestampModel
 # Create your models here.
 
 #figure out what to do when no more available 4 digits.
 #also optimize this because it is inefficient when db gets crowded.
+
+
+class RoundQueryset(models.QuerySet):
+    def created_at_interval(self, initial_date, final_date):
+        return self.filter(
+            Q(created_at__gte=initial_date) &
+            Q(created_at__lte=final_date)
+        )
+
+
 def random_4_digits():
     random_number = randint(1000, 9999)
     while True:
         if not Round.objects.filter(round_id=random_number).exists():
             return random_number
         random_number = randint(1000, 9999)
+
 
 class Course(models.Model):
     course_name = models.CharField(max_length=20)
@@ -33,12 +46,17 @@ class Course(models.Model):
     hole_17 = models.IntegerField(default=0)
     hole_18 = models.IntegerField(default=0)
 
+
 class Player(models.Model):
     player_name = models.CharField(max_length=50)
 
-class Round(models.Model):
+
+class Round(TimestampModel):
     round_id = models.IntegerField(primary_key=True, default=random_4_digits)
     course = models.ForeignKey(Course, on_delete=models.CASCADE, default=None)
+
+    objects = RoundQueryset.as_manager()
+
 
 class Score(models.Model):
     round = models.ForeignKey(Round, on_delete=models.CASCADE, default=None)

--- a/round/utils.py
+++ b/round/utils.py
@@ -1,0 +1,13 @@
+from django.db import models
+
+
+class TimestampModel(models.Model):
+    '''
+        Extend this model if you wish to have automatically updated
+        created_at and updated_at fields.
+    '''
+    class Meta:
+        abstract = True
+
+    created_at = models.DateTimeField(null=False, blank=True, auto_now_add=True)
+    updated_at = models.DateTimeField(null=False, blank=True, auto_now=True)


### PR DESCRIPTION
I added a filter to this model, now you can call it by using `round.created_at_interval(initial_date, final_date)` it will return a queryset with all rounds created in the interval